### PR TITLE
Add words to AudioResponse

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -80,6 +80,7 @@ type AudioResponse struct {
 	Duration float64                `json:"duration"`
 	Segments []AudioResponseSegment `json:"segments"`
 	Text     string                 `json:"text"`
+	Words    []AudioResponseWord    `json:"words"`
 
 	httpHeader
 }


### PR DESCRIPTION
Adds Words to the AudioResponse type so we can use the Timestamps and NoSpeechProb in results.
